### PR TITLE
Support image pull secrets for the Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ sudo cp <registry_data_directory>/certs/domain.crt /etc/docker/certs.d/localhost
 ```bash
 docker login 127.0.0.1:5000 -u <registry_username> -p pass <registry_password>
 ```
+8. Create a Kubernetes secret named `docker-secret` with your Docker login. This is so that Kubernetes can retrieve images from your private registry:
+```bash
+kubectl create secret docker-registry --docker-server <docker-registry-ip> --docker-username <registry_username> --docker-password <registry_password>
+```
 
 ## Modiry cwl-WES before installing
 1. Clone the cwl-WES Helm charts from the GitHub [repository](https://github.com/elixir-cloud-aai/cwl-WES).

--- a/scheduler_files/configFileCreator.py
+++ b/scheduler_files/configFileCreator.py
@@ -1,6 +1,16 @@
 # import uuid
-# import json
+import json
 import yaml
+import os
+
+
+configFileName=os.path.dirname(os.path.abspath(__file__)) + '/configuration.json'
+configFile=open(configFileName,'r')
+config=json.load(configFile)
+configFile.close()
+
+imagePullSecrets = config.get('imagePullSecrets', [])
+
 
 def createFile(name,machineType,image,
 		jobid,tmpFolder,workingDir,
@@ -96,6 +106,8 @@ def createFile(name,machineType,image,
 	manifest_data['spec']={'template':{'spec':{}}, 'backoffLimit':1}
 	if len(volumes)!=0:
 		manifest_data['spec']['template']['spec']['volumes']=volumes
+	if imagePullSecrets:
+		manifest_data['spec']['template']['spec']['imagePullSecrets'] = imagePullSecrets
 	manifest_data['spec']['template']['spec']['containers']=containers
 	# manifest_data['spec']['template']['spec']['nodeSelector']={'machine-type': machineType}
 	manifest_data['spec']['template']['spec']['restartPolicy']='Never'

--- a/scheduler_files/configuration-template.json
+++ b/scheduler_files/configuration-template.json
@@ -22,5 +22,9 @@
 	{
 		"local": "/data/docker/workflows",
 		"wesContainer": "/workflows"
-	}
+	},
+	"imagePullSecrets":
+	[
+		{"name": "docker-secret"}
+	]
 }


### PR DESCRIPTION
#### Summary

Support injecting `imagePullSecrets` to the pod templates created for workflow runs. This allows pulling images from registries that require authentication.

#### Changes

- Add a new `imagePullSecrets` configuration entry
- Configure `imagePullSecrets` on the generated pod definition (if any are configured).
- Update README instructions for the Docker registry

#### Testing

- Without imagePullSecrets, retrieving images fails for private registries.
- With this change, we can successfully retrieve Docker images, and jobs can proceed properly.

#### Notes

- In the generic case, this should probably be configured per software instead of being a global config option. However, this would require non-trivial database schema migrations and multiple changes on the backend and the UI, which is why we went with this simple solution at the moment.
