### PR TITLE
Add missing sql type definition

### DIFF
--- a/database_schema/schema_db.sql
+++ b/database_schema/schema_db.sql
@@ -16,6 +16,30 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: hist_type; Type: TYPE; Schema: public; Owner: schema
+--
+
+CREATE TYPE public.hist_type AS ENUM (
+    'job',
+    'workflow'
+);
+
+
+ALTER TYPE public.hist_type OWNER TO schema;
+
+--
+-- Name: visibility_types; Type: TYPE; Schema: public; Owner: schema
+--
+
+CREATE TYPE public.visibility_types AS ENUM (
+    'private',
+    'public'
+);
+
+
+ALTER TYPE public.visibility_types OWNER TO schema;
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;


### PR DESCRIPTION
- Added some missing SQL type definitions needed to properly restore the DB schema. 
- The types were deduced based on exploring the code base, therefore, might not be entirely correct.  
- Using `--schema-only` option when dumping the SQL schema might provide a way to export the types.    