### PR TITLE
Add option to disable the FTP deployment,

### DIFF
--- a/deployment/templates/ftp/ftp-deployment.yaml
+++ b/deployment/templates/ftp/ftp-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.ftp.active true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,3 +51,4 @@ spec:
       restartPolicy: Always
       imagePullSecrets:
         - name: schema-regcreds
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -91,7 +91,7 @@ postgres:
 # FTP service deployed alongside schema for TESK file access
 ftp:
   app_name: ftp
-
+  active: true
   deployment:
       image: diwis/schema-ftp:1
       username: tesk-1


### PR DESCRIPTION
 Add option to disable the FTP deployment, OpenShift does not allow to open FTP's port to the outside world