### PR TITLE
Add detection of environment variables and innitContainer section 

### DIFF
--- a/deployment/templates/_helpers.tpl
+++ b/deployment/templates/_helpers.tpl
@@ -1,6 +1,30 @@
 {{/*
 Create secret to access docker registry
 */}}
-{{- define "imagePullSecret" }}
+{{- define "deployment.imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"username\":\"%s\",\"password\":\"%s\",\"auth\": \"%s\"}}}" .Values.registry.url .Values.registry.deployment.username .Values.registry.deployment.password (printf "%s:%s" .Values.registry.deployment.username .Values.registry.deployment.password | b64enc) | b64enc }}
+{{- end }}
+
+{{- define "deployment.postgresql_user" }}
+{{- if hasPrefix "centos" .Values.postgres.deployment.image }}
+{{- print "POSTGRESQL_USER" }}
+{{- else }}
+{{- print "POSTGRES_USER" }}
+{{- end }}
+{{- end }}
+
+{{- define "deployment.postgresql_password" }}
+{{- if hasPrefix "centos" .Values.postgres.deployment.image -}}
+{{- print "POSTGRESQL_PASSWORD" -}}
+{{- else -}}
+{{- print "POSTGRES_PASSWORD" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "deployment.postgresql_database" }}
+{{- if hasPrefix "centos" .Values.postgres.deployment.image -}}
+{{- print "POSTGRESQL_DATABASE" -}}
+{{- else -}}
+{{- print "POSTGRES_DATABASE" -}}
+{{- end -}}
 {{- end }}

--- a/deployment/templates/postgres/postgres-deployment.yaml
+++ b/deployment/templates/postgres/postgres-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: {{ .Values.postgres.app_name }}
     spec:
+      {{- if not (hasPrefix "centos" .Values.postgres.deployment.image) }}
       initContainers:
       - name: volume-permissions
         image: busybox
@@ -22,20 +23,20 @@ spec:
         volumeMounts:
           - name: postgres-volume
             mountPath: /var/lib/postgresql/data
+      {{- end }}
       containers:
       - image: {{ .Values.postgres.deployment.image }}
         name: postgres
         env:
-          - name: POSTGRES_USER
+          - name: {{ include "deployment.postgresql_user" . }}
             value: {{ .Values.postgres.deployment.dbUsername }}
-          - name: POSTGRES_PASSWORD
+          - name: {{ include "deployment.postgresql_password" . }}
             value: {{ .Values.postgres.deployment.dbPassword }}
-          - name: POSTGRES_DB
+          - name: {{ include "deployment.postgresql_database" . }}
             value: {{ .Values.postgres.deployment.dbName }}
         volumeMounts:
           - mountPath: /var/lib/postgresql/data
             name: postgres-volume
-        
       volumes:
         - name: postgres-volume
           persistentVolumeClaim:

--- a/deployment/templates/registry/registry-creds.yaml
+++ b/deployment/templates/registry/registry-creds.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  .dockerconfigjson: {{ template "imagePullSecret" . }}
+  .dockerconfigjson: "{{ template "deployment.imagePullSecret" . }}"
 kind: Secret
 metadata:
   name: registry-creds


### PR DESCRIPTION
Based on the image prefix (`centos`) it changes the name of variables where the username, database name and password are passed to the pod. Also deactivates the innit Container section.

All this because OpenShift does not support the official PostgreSQL  image.