### PR TITLE
Remove extra suffix to DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ helm install schema-app deployment -f deployment/values.yaml
 
 4. Create the database structure and add required data:
 ```bash
-kubectl -n schema exec -it <schema-pod-id> psql -h postgres.schema.svc.cluster.local -U <your-db-username> -d <your-db-name> -f /app/web/schema/database_schema/schema_db.sql
+kubectl -n schema exec -it <schema-pod-id> psql -h postgres -U <your-db-username> -d <your-db-name> -f /app/web/schema/database_schema/schema_db.sql
 ```
 5. Run the same command for all migration files ```/app/web/schema/database-schema/migration-xx.sql``` in order. If you are upgrading to the latest version of SCHeMa, please run the migration files that have been published since the last version.
 

--- a/deployment/config-files/configuration.json
+++ b/deployment/config-files/configuration.json
@@ -6,16 +6,16 @@
 		"username": "{{ .Values.registry.deployment.username }}",
 		"password": "{{ .Values.registry.deployment.password }}"
 	},
-	"database": 
+	"database":
 	{
-		"host":"postgres.schema.svc.cluster.local",
+		"host":"postgres",
 		"username": "{{ .Values.postgres.deployment.dbUsername }}",
 		"password": "{{ .Values.postgres.deployment.dbPassword }}",
 		"database": "{{ .Values.postgres.deployment.dbName }}"
 	},
 	"localftp":
 	{
-		"domain": "ftp.schema.svc.cluster.local",
+		"domain": "ftp",
 		"username": "{{ .Values.ftp.deployment.username }}",
 		"password": "{{ .Values.ftp.deployment.password }}"
 	},
@@ -25,7 +25,7 @@
 	],
 	"ftp-creds":
 	{
-		"ftp.schema.svc.cluster.local":
+		"ftp":
 		{
 			"username": "{{ .Values.ftp.deployment.username }}",
 			"password": "{{ .Values.ftp.deployment.password }}"

--- a/deployment/config-files/db.php
+++ b/deployment/config-files/db.php
@@ -2,7 +2,7 @@
 
 return [
     'class' => 'yii\db\Connection',
-    'dsn' => 'pgsql:host=postgres.schema.svc.cluster.local;dbname={{ .Values.postgres.deployment.dbName }}',
+    'dsn' => 'pgsql:host=postgres;dbname={{ .Values.postgres.deployment.dbName }}',
     'username' => '{{ .Values.postgres.deployment.dbUsername }}',
     'password' => '{{ .Values.postgres.deployment.dbPassword }}',
     'charset' => 'utf8',

--- a/deployment/config-files/params.php
+++ b/deployment/config-files/params.php
@@ -21,7 +21,7 @@ return [
     /*
      * Change the following parameters according to your installation
      */
-    'ftpIp' => 'ftp.schema.svc.cluster.local',
+    'ftpIp' => 'ftp',
     'teskEndpoint' => '{{ .Values.tesk.url }}',
     'wesEndpoint' => '{{ .Values.wes.url }}',
     'standalone' => {{ .Values.standalone.isStandalone }},

--- a/deployment/templates/schema/schema-secret.yaml
+++ b/deployment/templates/schema/schema-secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 stringData:
-  configuration.json: "{\n\t\n\t\"registry\": \"{{ .Values.registry.url }}\",\n\t\"registryAuth\":\n\t{\n\t\t\"username\":\"{{ .Values.registry.deployment.username }}\",\n\t\t\"password\": \"{{ .Values.registry.deployment.password }}\"\n\t},\n\t\"database\": \n\t{\n\t\t\"host\":\"postgres.schema.svc.cluster.local\",\n\t\t\"username\":\"{{ .Values.postgres.deployment.dbUsername }}\",\n\t\t\"password\": \"{{ .Values.postgres.deployment.dbPassword }}\",\n\t\t\"database\": \"{{ .Values.postgres.deployment.dbName }}\"\n\t},\n\t\"localftp\":\n\t{\n\t\t\"domain\":\"ftp.schema.svc.cluster.local\",\n\t\t\"username\": \"{{ .Values.ftp.deployment.username }}\",\n\t\t\"password\": \"{{ .Values.ftp.deployment.password }}\"\n\t},\n\t\"imagePullSecrets\":\n\t[\n\t\t{\"name\":\"registry-creds\"}\n\t],\n\t\"ftp-creds\":\n\t{\n\t\t\"ftp.schema.svc.cluster.local\":\n\t\t{\n\t\t\t\"username\":\"{{ .Values.ftp.deployment.username }}\",\n\t\t\t\"password\": \"{{ .Values.ftp.deployment.password }}\"\n\t\t}\n\t},\n\t\"namespaces\":\n\t{\n\t\t\"registry\":\"schema\",\n\t\t\"jobs\":\"schema\",\n\t\t\"tesk\": \"tesk\"\n\t}\n}"
+  configuration.json: "{\n\t\n\t\"registry\": \"{{ .Values.registry.url }}\",\n\t\"registryAuth\":\n\t{\n\t\t\"username\":\"{{ .Values.registry.deployment.username }}\",\n\t\t\"password\": \"{{ .Values.registry.deployment.password }}\"\n\t},\n\t\"database\": \n\t{\n\t\t\"host\":\"postgres\",\n\t\t\"username\":\"{{ .Values.postgres.deployment.dbUsername }}\",\n\t\t\"password\": \"{{ .Values.postgres.deployment.dbPassword }}\",\n\t\t\"database\": \"{{ .Values.postgres.deployment.dbName }}\"\n\t},\n\t\"localftp\":\n\t{\n\t\t\"domain\":\"ftp\",\n\t\t\"username\": \"{{ .Values.ftp.deployment.username }}\",\n\t\t\"password\": \"{{ .Values.ftp.deployment.password }}\"\n\t},\n\t\"imagePullSecrets\":\n\t[\n\t\t{\"name\":\"registry-creds\"}\n\t],\n\t\"ftp-creds\":\n\t{\n\t\t\"ftp\":\n\t\t{\n\t\t\t\"username\":\"{{ .Values.ftp.deployment.username }}\",\n\t\t\t\"password\": \"{{ .Values.ftp.deployment.password }}\"\n\t\t}\n\t},\n\t\"namespaces\":\n\t{\n\t\t\"registry\":\"schema\",\n\t\t\"jobs\":\"schema\",\n\t\t\"tesk\": \"tesk\"\n\t}\n}"
   db.php: |
     <?php
 
     return [
         'class' => 'yii\db\Connection',
-        'dsn' => 'pgsql:host=postgres.schema.svc.cluster.local;dbname={{ .Values.postgres.deployment.dbName }}',
+        'dsn' => 'pgsql:host=postgres;dbname={{ .Values.postgres.deployment.dbName }}',
         'username' => '{{ .Values.postgres.deployment.dbUsername }}',
         'password' => '{{ .Values.postgres.deployment.dbPassword }}',
         'charset' => 'utf8',
@@ -39,7 +39,7 @@ stringData:
         /*
          * Change the following parameters according to your installation
          */
-        'ftpIp' => 'ftp.schema.svc.cluster.local',
+        'ftpIp' => 'ftp',
         'teskEndpoint' => '{{ .Values.tesk.url }}',
         'wesEndpoint' => '{{ .Values.wes.url }}',
         'standalone' => {{ .Values.standalone.isStandalone }},


### PR DESCRIPTION
Remove extra suffix to DNS names, all DNS names inside the same namespace resolv without this suffix. It was hardwired to schema, and we cannot use schema as the name of the name of the namespace as we have several prod/dev/...