### PR TITLE
Add missing params.php, otherwise the application fails

### DIFF
--- a/deployment/templates/schema/schema-secret.yaml
+++ b/deployment/templates/schema/schema-secret.yaml
@@ -43,6 +43,9 @@ stringData:
         'teskEndpoint' => '{{ .Values.tesk.url }}',
         'wesEndpoint' => '{{ .Values.wes.url }}',
         'standalone' => {{ .Values.standalone.isStandalone }},
+        'logo-footer' => 'img/elixir-dark.png',
+        'name' => 'SCHeMa scheduler',
+        'copyright' => 'Athena RC 2021',
         'standaloneResources'=>
         [
             'maxCores'=> {{ .Values.standalone.resources.maxCores }},


### PR DESCRIPTION
3 new parameters were added to the PHP code. For the Helm chart to work, they had to be added to `params.php`. I added the values that were before in the code:
            'logo-footer' 'img/elixir-dark.png',
            'name'  'SCHeMa scheduler
            'copyright' 'Athena RC 2021'
