### PR TITLE
Call cancel to WES when the Button is pressed in Schema

### DIFF
--- a/models/Workflow.php
+++ b/models/Workflow.php
@@ -528,12 +528,7 @@ class Workflow extends \yii\db\ActiveRecord
         }
         else if ($statusCode==500)
         {
-            $error='An unexpected error occurred. Please contact an administrator';
-            return ['jobid'=>'','error'=>$error];
-        }
-        else if ($statusCode==500)
-        {
-            $error='Error 500. Please contact an administrator';
+            $error='An unexpected error occurred (500). Please contact an administrator';
             return ['jobid'=>'','error'=>$error];
         }
         else if ($statusCode==502)

--- a/web/js/workflow/logs.js
+++ b/web/js/workflow/logs.js
@@ -59,8 +59,9 @@ $(document).ready(function()
     {
       var jobid=$("#hidden_jobid_input").val();
       var name=$("#hidden_name_input").val();
+      // workflow/clean-up => actionCleanUp
       $.ajax({
-            url: "index.php?r=software/clean-up",
+            url: "index.php?r=workflow/clean-up",
             type: "GET",
             data: { "jobid": jobid, "name": name, "status": "Canceled"},
             dataType: "html",


### PR DESCRIPTION
This now calls cancel to WES' API when the Button "Cancel" is pressed in Schema in a workflow.

Previously it was directly calling the clean function from the Software model. Now it does just before a call to the REST API endpoint.