### PR TITLE
Fix QUEUE error, now it shows "waiting time"

### DIFF
--- a/models/Workflow.php
+++ b/models/Workflow.php
@@ -23,6 +23,8 @@
 
 namespace app\models;
 
+use Exception;
+
 use Yii;
 use webvimark\modules\UserManagement\models\User;
 use yii\httpclient\Client;
@@ -657,7 +659,13 @@ class Workflow extends \yii\db\ActiveRecord
         $runLog=$data['run_log'];
         $taskLogs=$data['task_logs'];
         $status=$data['state'];
-        $start=new \DateTime($runLog['task_started']);
+
+        try {
+            $start=new \DateTime($runLog['task_started']);
+        } catch (Exception $ex) {
+            $start=new \DateTime($runLog['task_received']);
+        }
+
         $now = new \DateTime();
 
         $running_time=$start->diff($now);


### PR DESCRIPTION
When the task has not yet started the field 'task_started' is missing, this prevents the error and uses 'task_received' so now it is possible to know since when the task has been QUEUING