### PR TITLE
Fix order of exec parameters

### DIFF
--- a/controllers/WorkflowController.php
+++ b/controllers/WorkflowController.php
@@ -991,9 +991,9 @@ class WorkflowController extends Controller
             {
                 // $mountExistError=true;
                 $command="mkdir -p $folder";
-                Software::exec_log($command,$ret,$out);
+                Software::exec_log($command,$out,$ret);
                 $command="chmod 777 $folder";
-                Software::exec_log($command,$ret,$out);
+                Software::exec_log($command,$out,$ret);
             }
         }
         

--- a/models/SoftwareUpload.php
+++ b/models/SoftwareUpload.php
@@ -142,7 +142,7 @@ class SoftwareUpload extends \yii\db\ActiveRecord
         if (!is_dir($dataFolder))
         {
             $command="mkdir -p $dataFolder";
-            Software::exec_log($command,$ret,$outdir);
+            Software::exec_log($command,$outdir,$ret);
         }
         //add dois string in a file and pass it on to python
 

--- a/models/SoftwareUploadExisting.php
+++ b/models/SoftwareUploadExisting.php
@@ -149,7 +149,7 @@ class SoftwareUploadExisting extends \yii\db\ActiveRecord
         if (!is_dir($dataFolder))
         {
             $command="mkdir -p $dataFolder";
-            Software::exec_log($command,$ret,$outdir);
+            Software::exec_log($command,$outdir,$ret);
         }
 
 

--- a/models/WorkflowUpload.php
+++ b/models/WorkflowUpload.php
@@ -124,7 +124,7 @@ class WorkflowUpload extends \yii\db\ActiveRecord
         if (!is_dir($dataFolder))
         {
             $command="mkdir -p $dataFolder";
-            Software::exec_log($command,$ret,$outdir);
+            Software::exec_log($command,$outdir,$ret);
         }
         //add dois string in a file and pass it on to python
 


### PR DESCRIPTION
Some calls to exec were done using the wrong order, this caused problems when an int was passed to an array parameter or viceversa.