### PR TITLE
Remove log error when DOI is not set and rm tryes to rm the empty file

### DIFF
--- a/models/SoftwareUpload.php
+++ b/models/SoftwareUpload.php
@@ -199,7 +199,10 @@ class SoftwareUpload extends \yii\db\ActiveRecord
         {
             case 0:
                 $success="Image successfully uploaded!";
-                Software::exec_log("rm $doiFile");
+                if($doiFile!='\'\'')
+                {
+                    Software::exec_log("rm $doiFile");
+                }
                 break;
             case 2:
                 $errors.="Error: code $ret. ";

--- a/models/WorkflowUpload.php
+++ b/models/WorkflowUpload.php
@@ -197,7 +197,10 @@ class WorkflowUpload extends \yii\db\ActiveRecord
         {
             case 0:
                 $success="Workflow successfully uploaded!";
-                Software::exec_log("rm $doiFile");
+                if($doiFile!='\'\'')
+                {
+                    Software::exec_log("rm $doiFile");
+                }
                 break;
             case 2:
                 $errors.="Error: code $ret. ";


### PR DESCRIPTION
Small fix, when DOI is not part of the workflow, the rm end ups trying to remove the empty string. Polluting the logs.