### PR TITLE
Fix session error HTTP/500 

### DIFF
--- a/controllers/SoftwareController.php
+++ b/controllers/SoftwareController.php
@@ -196,8 +196,12 @@ class SoftwareController extends Controller
 
     public function actionRun($name, $version)
     {
+		if (!isset($_SESSION['selected_project'])) {
+			$project='';
+		} else {
+			$project=$_SESSION['selected_project'];
+		}
 
-        $project=$_SESSION['selected_project'];
         $software=Software::find()->where(['name'=>$name,'version'=>$version])->one();
         $software_id=$software->id;
         $software_instructions=$software->instructions;


### PR DESCRIPTION
When selected_project is not defined in the session, Schema shows a HTTP/500 error